### PR TITLE
Build Arduino sketch for the Controller firmware via GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+on:
+  - push
+  - pull_request
+jobs:
+  compile_sketch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arduino/compile-sketches@v1
+        with:
+          fqbn: arduino:avr:nano
+          sketch-paths: Arduino/SelfomatController

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
-          required-libraries: Adafruit NeoPixel
+          required-libraries: Adafruit NeoPixel@1.10.6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,3 +10,5 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
+          libraries: |
+            - name: Adafruit_NeoPixel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
-          libraries: "Adafruit NeoPixel"
+          libraries: ""Adafruit NeoPixel""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
-          required-libraries: Adafruit NeoPixel@1.10.6
+          libraries: Adafruit NeoPixel@1.10.6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ on:
   - push
   - pull_request
 jobs:
-  compile_sketch:
+  compile_controller_board_arduino_sketch:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,3 +12,4 @@ jobs:
           sketch-paths: Arduino/SelfomatController
           libraries: |
             "Adafruit NeoPixel"
+            "PinChangeInterrupt"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
-          libraries: Adafruit\ NeoPixel@1.10.6
+          libraries: "Adafruit NeoPixel"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,5 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
-          libraries: ""Adafruit NeoPixel""
+          libraries: |
+            "Adafruit NeoPixel"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,5 +10,4 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
-          required-libraries: |
-            - name: Adafruit_NeoPixel
+          required-libraries: Adafruit NeoPixel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: arduino/compile-sketches@v1
         with:
-          fqbn: arduino:avr:nano
+          fqbn: arduino:avr:nano  # fully qualified board name (fqbn)
+          verbose: true
+          enable-deltas-report: true
+          enable-warnings-report: true
           sketch-paths: Arduino/SelfomatController
           libraries: |
             "Adafruit NeoPixel"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,5 +10,5 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
-          libraries: |
+          required-libraries: |
             - name: Adafruit_NeoPixel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           fqbn: arduino:avr:nano
           sketch-paths: Arduino/SelfomatController
-          libraries: Adafruit NeoPixel@1.10.6
+          libraries: Adafruit\ NeoPixel@1.10.6


### PR DESCRIPTION
This basically introduces continuous integration for the self-o-mat Controller firmware into the repository.
It's implemented in a basic YAML file, see the code changes.
Could be extended to automatic deployment of executables.