### PR TITLE
Add software serial based logging (implements #33)

### DIFF
--- a/Arduino/SelfomatController/AgreementState.cpp
+++ b/Arduino/SelfomatController/AgreementState.cpp
@@ -9,7 +9,7 @@ bool AgreementState::processCommand(const uint8_t* buffer, size_t size) {
     sendCommand('A');
     return true;
   }
-  
+
   // Process base commands.
   if(BaseState::processCommand(buffer, size))
     return true;
@@ -31,11 +31,11 @@ void AgreementState::animationStep(unsigned long dt) {
       }
     }
 
-  
+
     float angleOffset = timeInState()/300.0f;
     float anglePerLed = (2.0 * PI) / ring.numPixels();
     for(int j = 0; j < ring.numPixels(); j++) {
-      float angle = (float)j * anglePerLed + angleOffset;   
+      float angle = (float)j * anglePerLed + angleOffset;
       float sin_x = sin(angle);
       uint8_t brightness = sin_x*sin_x * 255.0f * b;
       ring.setPixelColor(j, 0, brightness, 0);
@@ -48,9 +48,10 @@ BaseState* AgreementState::logicStep() {
     shouldExit = true;
     sendCommand('c');
   }
-  
+
   if(shouldExit && exitAnimationDone) {
     sendCommand('a');
+    logger.println( F("exit to -> IdleState") );
     return &IdleState::INSTANCE;
   }
   return this;

--- a/Arduino/SelfomatController/BootingState.cpp
+++ b/Arduino/SelfomatController/BootingState.cpp
@@ -45,6 +45,7 @@ BaseState* BootingState::logicStep() {
     return parentStep;
 
   if(shouldExit && exitAnimationDone) {
+    logger.println( F("exit to -> IdleState") );
     return &IdleState::INSTANCE;
   }
 
@@ -59,7 +60,7 @@ void BootingState::enter() {
 void BootingState::exit() {
   // Booting done, we need a heartbeat. Assume we got it now
   heartbeatDeactivated = false;
-  lastHeartbeat = millis();  
+  lastHeartbeat = millis();
 }
 
 bool BootingState::needsHeartbeat() {

--- a/Arduino/SelfomatController/BusyState.cpp
+++ b/Arduino/SelfomatController/BusyState.cpp
@@ -33,18 +33,20 @@ BaseState* BusyState::logicStep() {
   if(flashTriggered) {
     if(settings.flashDurationMicros < 0) {
       delay(10);
-    } else {  
+    } else {
       while(micros() - flashStartMicros < settings.flashDurationMicros);
     }
     digitalWrite(PIN_FLASH_ON, LOW);
     flashTriggered = false;
   }
-  
+
   // timeout in busy state
   if(timeInState() > 15000 || exitIdle) {
+    logger.println(  F("exit to -> IdleState") );
     return &IdleState::INSTANCE;
   }
   if(exitPrint) {
+    logger.println( F("exit to -> PrintingState") );
     return &PrintingState::INSTANCE;
   }
   return this;

--- a/Arduino/SelfomatController/CountDownState.cpp
+++ b/Arduino/SelfomatController/CountDownState.cpp
@@ -11,9 +11,9 @@ bool CountDownState::processCommand(const uint8_t* buffer, size_t size) {
 void CountDownState::animationStep(unsigned long dt) {
   uint32_t color = colors[animationCycle];
   float percentage = ((float)timeInState() - animationCycle * oneCycleMillis) / oneCycleMillis;
-  
+
   float pixelBorder = ring.numPixels() - ring.numPixels() * percentage;
-  
+
   for(int8_t i=0; i<ring.numPixels(); i++) {
 
     if(i > pixelBorder) {
@@ -37,6 +37,7 @@ BaseState* CountDownState::logicStep() {
   if(timeInState() > settings.countDownMillis) {
     // Trigger the capture and go to idle
     sendCommand('t');
+    //logger.println("Cntdn expired, triggered -> BusyState");
     return &BusyState::INSTANCE;
   }
   return this;

--- a/Arduino/SelfomatController/Logging.cpp
+++ b/Arduino/SelfomatController/Logging.cpp
@@ -1,8 +1,10 @@
 #include "Logging.h"
-#include <NeoSWSerial.h>
 
-#ifndef NEOSWSERIAL_EXTERNAL_PCINT
-#error NEOSWSERIAL_EXTERNAL_PCINT needs to be defined inside of NeoSWSerial.h or as compile flag.
+#ifdef LOGGING_ACTIVE
+  #include <NeoSWSerial.h>
+  #ifndef NEOSWSERIAL_EXTERNAL_PCINT
+  #error NEOSWSERIAL_EXTERNAL_PCINT needs to be defined inside of NeoSWSerial.h or as compile flag.
+  #endif
 #endif
 
 Logging::Logging(uint8_t transmitPin) {

--- a/Arduino/SelfomatController/Logging.cpp
+++ b/Arduino/SelfomatController/Logging.cpp
@@ -1,0 +1,28 @@
+#include "Logging.h"
+#include <NeoSWSerial.h>
+
+#ifndef NEOSWSERIAL_EXTERNAL_PCINT
+#error NEOSWSERIAL_EXTERNAL_PCINT needs to be defined inside of NeoSWSerial.h or as compile flag.
+#endif
+
+Logging::Logging(uint8_t transmitPin) {
+#ifdef LOGGING_ACTIVE
+  /* using the same pin for RX and TX seems to work; we won't RX anyways */
+  pSwSerial = new NeoSWSerial(transmitPin, transmitPin);
+#endif
+}
+
+void Logging::begin(uint16_t baudRate) {
+#ifdef LOGGING_ACTIVE
+  ((NeoSWSerial*)pSwSerial)->begin(baudRate);
+  ((NeoSWSerial*)pSwSerial)->ignore(); // do not use RX
+#endif
+}
+
+size_t Logging::write(uint8_t txChar) {
+#ifdef LOGGING_ACTIVE
+  return ((NeoSWSerial*)pSwSerial)->write(txChar);
+#else
+  return 0;
+#endif
+}

--- a/Arduino/SelfomatController/Logging.h
+++ b/Arduino/SelfomatController/Logging.h
@@ -1,0 +1,20 @@
+#ifndef LOGGING_H
+#define LOGGING_H
+
+#include "Print.h"
+
+#define LOGGING_ACTIVE /* Comment out when logging is unwanted; could also overwrite class! */
+
+class Logging : public Print {
+public:
+  Logging(uint8_t transmitPin);
+
+  void begin(uint16_t baudRate=38400);
+
+  size_t write(uint8_t txChar);
+
+private:
+  void* pSwSerial;
+};
+
+#endif

--- a/Arduino/SelfomatController/Logging.h
+++ b/Arduino/SelfomatController/Logging.h
@@ -3,7 +3,7 @@
 
 #include "Print.h"
 
-#define LOGGING_ACTIVE /* Comment out when logging is unwanted; could also overwrite class! */
+//#define LOGGING_ACTIVE /* Comment out when logging is unwanted; could also overwrite class! */
 
 class Logging : public Print {
 public:

--- a/Arduino/SelfomatController/OffState.cpp
+++ b/Arduino/SelfomatController/OffState.cpp
@@ -18,6 +18,7 @@ BaseState* OffState::logicStep() {
 
   if (digitalRead(PIN_SWITCH) == LOW) {
     // The switch is on and we're allowed to exit the off state->do it
+    logger.println( F("HW switch LOW -> booting") );
     return &BootingState::INSTANCE;
   }
   return this;
@@ -25,10 +26,11 @@ BaseState* OffState::logicStep() {
 
 void OffState::enter() {
   BaseState::enter();
-  
+
   // read settings
+  logger.println( F("Read settings on entry") );
   readSettings();
-  
+
   allowExitState = false;
 
 

--- a/Arduino/SelfomatController/globals.cpp
+++ b/Arduino/SelfomatController/globals.cpp
@@ -26,5 +26,7 @@ FastCRC16 CRC16;
 
 COBSSpacePacketSerial packetSerial;
 
+Logging logger(PIN_SWSERIAL_LOGGING_TX);
+
 unsigned long lastHeartbeat = 0;
 bool heartbeatDeactivated = false;

--- a/Arduino/SelfomatController/globals.h
+++ b/Arduino/SelfomatController/globals.h
@@ -1,6 +1,7 @@
 #ifndef GLOBALS_H
 #define GLOBALS_H
 #include "stdint.h"
+#include "Logging.h"
 #include <Adafruit_NeoPixel.h>
 #include "FastCRC.h"
 #include "PacketSerial.h"
@@ -8,21 +9,22 @@
 /*
  * PIN Defines
  */
-#define PIN_LED 4
-#define PIN_LED_OFF 9
-
-#define PIN_STATUS 20
+#define PIN_LED                 (6) //(4)
+#define PIN_LED_OFF             (9)
+#define PIN_STATUS              (20)
 
 // DO NOT CHANGE!!! WE HAVE DIRECT HARDWARE ACCESS ON THIS PIN!!!!
-#define PIN_FLASH_ON 11
-#define PIN_FLASH_CAM_TRIGGER 7
+#define PIN_FLASH_ON            (11)
+#define PIN_FLASH_CAM_TRIGGER   (7)
 
-#define PIN_BUTTON 2
-#define PIN_SWITCH 3
-#define PIN_ON 8
-#define PIN_LEVEL_SHIFTER_OE 19
+#define PIN_BUTTON              (2)
+#define PIN_SWITCH              (3)
+#define PIN_ON                  (8)
+#define PIN_LEVEL_SHIFTER_OE    (19)
 
-#define PIXEL_TYPES 2
+#define PIN_SWSERIAL_LOGGING_TX (13)
+
+#define PIXEL_TYPES             (2)
 extern neoPixelType supportedPixels[PIXEL_TYPES];
 
 
@@ -54,6 +56,7 @@ extern bool settingsDirty;
 extern Adafruit_NeoPixel ring;
 extern FastCRC16 CRC16;
 extern COBSSpacePacketSerial packetSerial;
+extern Logging logger;
 
 extern unsigned long lastHeartbeat;
 extern bool heartbeatDeactivated;

--- a/Arduino/SelfomatController/globals.h
+++ b/Arduino/SelfomatController/globals.h
@@ -9,7 +9,7 @@
 /*
  * PIN Defines
  */
-#define PIN_LED                 (6) //(4)
+#define PIN_LED                 (6) //(4) TODO/FIXME: change back to 4 at least during review as this has been adapter for some special hardware
 #define PIN_LED_OFF             (9)
 #define PIN_STATUS              (20)
 


### PR DESCRIPTION
This pull request

* introduces a new class called `Logging` based on base class `Print` and therefore
* allows to use methods such as `Logging::println()`.
* It makes use of `NeoSWSerial` as other software serial impementations are not known to be compatible with the already used `PinChangeInterrupt` library. Make sure to `#define NEOSWSERIAL_EXTERNAL_PCINT // uncomment to use your own PCINT ISRs` inside of `NeoSWSerial.h`.
* Logging can be also deactivated commenting `#define LOGGING_ACTIVE` inside of `Logging.h` (also not requiring to resolve the NeoSWSerial` dependency). Probably should be the default as it currently is.

Side effects:
* By default the constant strings seem to use SRAM memory. With many debug logs, this can easily fill up your SRAM (which needs to be shared along with stack memory). I have seen side affects where adding more log strings will make the program not run properly, probably due to stack overflow (I saw this happen using Arduino Uno). Using the `F("mystring")` macro, puts it in `PROGMEM` therefore not taking away "expensive" SRAM. Seems to be an appropriate solution.
* The call of Logging functions is not free of cost: some delay will be introduced by the function calls. Not sure if this has any side effects on real-time execution/ time critical functionalities in some of the `SelfomatController` firmware, e.g. when triggering the flash or playing animations on the NeoPixel ring. This would require some testing with the xtech hardware which I don't have available.

Please note that the code also isn't fully tested yet on my side - but at least provides a proof-of-concept (PoC).