### PR TITLE
[ADD] Countdown to delay triggering in software

### DIFF
--- a/settings/dev.json
+++ b/settings/dev.json
@@ -8,5 +8,6 @@
   "image_dir": "/tmp",
   "show_led_setup": true,
   "force_image_dir_mountpoint": 0,
-  "fullscreen": false
+  "fullscreen": false,
+  "trigger_delay": 5
 }

--- a/src/logic/BoothLogic.h
+++ b/src/logic/BoothLogic.h
@@ -60,7 +60,7 @@ namespace selfomat {
         class BoothLogic : public ILogicController {
         public:
             explicit BoothLogic(ICamera *camera, IGui *gui, bool has_button, const string &button_port, bool has_flash,
-                                string imageDir, bool force_image_dir_mountpoint, bool disable_watchdog, bool show_led_setup, bool autofocus_before_trigger) : camera(camera), gui(gui),
+                                string imageDir, bool force_image_dir_mountpoint, bool disable_watchdog, bool show_led_setup, bool autofocus_before_trigger, int trigger_delay) : camera(camera), gui(gui),
                                                                         imageProcessor(gui),
                                                                         printerManager(gui),
                                                                         has_button(has_button),
@@ -70,7 +70,8 @@ namespace selfomat {
                                                                         selfomatController(),
                                                                         force_image_dir_mountpoint(force_image_dir_mountpoint),
                                                                         show_led_setup(show_led_setup),
-                                                                        autofocus_before_trigger(autofocus_before_trigger) {
+                                                                        autofocus_before_trigger(autofocus_before_trigger),
+                                                                        trigger_delay(trigger_delay) {
                 selfomatController.setLogic(this);
                 this->triggered = false;
                 this->disable_watchdog = disable_watchdog;
@@ -94,6 +95,7 @@ namespace selfomat {
             bool show_led_setup;
             bool autofocus_before_trigger;
             bool force_image_dir_mountpoint;
+            int trigger_delay;
 
             int returnCode = 0;
             string imageDir;
@@ -118,6 +120,8 @@ namespace selfomat {
             bool isLogicThreadRunning, isCameraThreadRunning, isPrinterThreadRunning;
             boost::mutex triggerMutex;
             bool triggered;
+            boost::mutex triggerCurrentDelayMutex;
+            int triggerCurrentDelay = -1;
 
             // We have a second thread running which first tries to get the jpegImageMutex
             // as soon as it has the jpegImageMutex it prepares for printing.
@@ -161,10 +165,11 @@ namespace selfomat {
             void readSettings();
             void writeSettings();
 
+            void triggerDelayThread();
+
             void cameraThread();
 
             void logicThread();
-
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,6 +122,7 @@ int main(int argc, char *argv[]) {
     bool force_image_dir_mountpoint = true;
     bool autofocus_before_trigger = false;
     bool fullscreen = true;
+    int trigger_delay = 0;
     string button_port_name;
     string image_dir;
 
@@ -148,6 +149,7 @@ int main(int argc, char *argv[]) {
         force_image_dir_mountpoint = ptree.get<bool>("force_image_dir_mountpoint", true);
         autofocus_before_trigger = ptree.get<bool>("autofocus_before_trigger", false);
         fullscreen = ptree.get<bool>("fullscreen", true);
+        trigger_delay = ptree.get<int>("trigger_delay", 0);
     } catch (boost::exception &e) {
         LOG_E(TAG, "Error loading properties. Using defaults.");
     }
@@ -159,7 +161,7 @@ int main(int argc, char *argv[]) {
     LOG_D(TAG, "Force Imagedir mountpoint: ", std::to_string(force_image_dir_mountpoint));
     LOG_D(TAG, "Autofocus Before Trigger: ", std::to_string(autofocus_before_trigger));
     LOG_D(TAG, "Fullscreen: ", std::to_string(fullscreen));
-
+    LOG_D(TAG, "Trigger delay: ", std::to_string(trigger_delay));
 
     // We'll set the controller later when logic is initialized
     BoothGui *boothGuiPtr = new BoothGui(fullscreen, debug, nullptr);
@@ -181,7 +183,7 @@ int main(int argc, char *argv[]) {
 
     LOG_I(TAG, "Started Camera");
 
-    p_logic = new logic::BoothLogic(p_cam, p_gui, has_button, button_port_name, has_flash, image_dir, force_image_dir_mountpoint, disable_watchdog, show_led_setup, autofocus_before_trigger);
+    p_logic = new logic::BoothLogic(p_cam, p_gui, has_button, button_port_name, has_flash, image_dir, force_image_dir_mountpoint, disable_watchdog, show_led_setup, autofocus_before_trigger, trigger_delay);
 
     LOG_I(TAG, "Started Logic");
 

--- a/src/ui/BoothGui.cpp
+++ b/src/ui/BoothGui.cpp
@@ -156,6 +156,11 @@ void BoothGui::renderThread() {
     iconText.setFillColor(COLOR_ALERT);
     iconText.setCharacterSize(50);
 
+    countdownText.setFont(hackFont);
+    countdownText.setFillColor(COLOR_COUNTDOWN);
+    countdownText.setCharacterSize(400);
+    countdownText.setStyle(1); // Bold
+
     alertText.setFont(mainFont);
     alertText.setFillColor(COLOR_ALERT);
     alertText.setCharacterSize(50);
@@ -440,6 +445,7 @@ void BoothGui::renderThread() {
                 break;
         }
 
+        drawCountdown();
         drawAlerts();
         drawDebug();
 
@@ -580,6 +586,23 @@ void BoothGui::drawAgreement(float alpha) {
     }
 }
 
+void BoothGui::drawCountdown() {
+    if (currentState == STATE_AGREEMENT) {
+      return;
+    }
+
+    countdownMutex.lock();
+    int localCountdown = countdown;
+    countdownMutex.unlock();
+
+    if (localCountdown > -1) {
+        countdownText.setString(std::to_string(localCountdown));
+        countdownText.setPosition((window.getSize().x - countdownText.getLocalBounds().width) / 2,
+                                  countdownText.getLocalBounds().height / 2.0f);
+        window.draw(countdownText);
+    }
+}
+
 void BoothGui::drawAlerts() {
 
     if (currentState == STATE_AGREEMENT) {
@@ -710,6 +733,13 @@ void BoothGui::hideAgreement()  {
         return;
 
     setState(STATE_TRANS_AGREEMENT);
+}
+
+
+void BoothGui::updateCountdown(int new_countdown) {
+    countdownMutex.lock();
+    countdown = new_countdown;
+    countdownMutex.unlock();
 }
 
 bool BoothGui::hasAlert(ALERT_TYPE type) {

--- a/src/ui/BoothGui.h
+++ b/src/ui/BoothGui.h
@@ -28,6 +28,7 @@
 
 #define COLOR_MAIN          sf::Color(20, 64, 66, 255)
 #define COLOR_MAIN_LIGHT    sf::Color(155, 194, 189)
+#define COLOR_COUNTDOWN     sf::Color(128, 128, 128)
 #define COLOR_ALERT         sf::Color(200, 0, 0)
 
 namespace selfomat {
@@ -63,6 +64,9 @@ namespace selfomat {
             GUI_STATE currentState;
             sf::Clock stateTimer;
 
+            boost::mutex countdownMutex;
+            int countdown = -1;
+
             boost::mutex alertMutex;
             std::map<ALERT_TYPE, Alert> alerts;
             sf::Clock alertTimer;
@@ -75,6 +79,7 @@ namespace selfomat {
             sf::Color clearColor;
             sf::Text debugText;
             sf::Text iconText;
+            sf::Text countdownText;
             sf::Text alertText;
             sf::Text printText;
             sf::Text agreementText;
@@ -127,6 +132,7 @@ namespace selfomat {
             float easeOutSin(float t, float b, float c, float d);
 
             void drawPrintOverlay(float percentage = 1.0f);
+            void drawCountdown();
             void drawAlerts();
             void drawAgreement(float alpha = 1);
             void drawDebug();
@@ -186,6 +192,8 @@ namespace selfomat {
 
             void showAgreement() override;
             void hideAgreement() override;
+
+            void updateCountdown(int new_countdown) override;
 
             bool hasAlert(ALERT_TYPE type) override;
             void addAlert(ALERT_TYPE type, std::wstring text, bool autoRemove = false, bool isHint = false) override;

--- a/src/ui/IGui.h
+++ b/src/ui/IGui.h
@@ -65,6 +65,8 @@ namespace selfomat {
 
             virtual void notifyPreviewIncoming() = 0;
 
+            virtual void updateCountdown(int new_countdown) = 0;
+
             virtual bool hasAlert(ALERT_TYPE type) = 0;
             virtual void addAlert(ALERT_TYPE type, std::wstring text, bool autoRemove = false, bool isHint = false) = 0;
             virtual void removeAlert(ALERT_TYPE type) = 0;

--- a/src/ui/NopGui.cpp
+++ b/src/ui/NopGui.cpp
@@ -35,7 +35,8 @@ void NopGui::notifyPreviewIncoming() {
     std::cout << "preview incoming callback" << std::endl;
 }
 
-
+void NopGui::updateCountdown(int new_countdown) {
+}
 
 void NopGui::addAlert(ALERT_TYPE type, std::wstring text, bool autoRemove, bool isHint) {
 

--- a/src/ui/NopGui.h
+++ b/src/ui/NopGui.h
@@ -27,6 +27,8 @@ namespace selfomat {
             void notifyPreviewIncoming() override;
 
 
+            void updateCountdown(int new_countdown) override;
+
             void addAlert(ALERT_TYPE type, std::wstring text, bool autoRemove, bool isHint) override;
 
             void removeAlert(ALERT_TYPE type) override;


### PR DESCRIPTION
This commit adds countdown functionality, in order to show in the GUI a countdown before the trigger is done. Using a separate thread, the countdown is decremented and the countdown value is send to the GUI.