### PR TITLE
Update README.md: clone git recursively again because of served submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ __If you're not sure how to do this, we provide a hardware kit which includes th
 
 ## Clone
 
-```git clone https://github.com/xtech/self-o-mat.git```
+```git clone --recursive https://github.com/xtech/self-o-mat.git```
+
+_Hint: `--recursive` is required to clone git submodules._
 
 ## Installation
 Installation is simple - just follow these steps:


### PR DESCRIPTION
TL;DR: Tell people to `git clone --recursive` (again).

---

Hi Clemens!

Intro: I was playing around with adding a grayscale filter - simply for having a filter and checking how things work with templates (see https://github.com/xtech/self-o-mat/issues/40). I was able to add the C++ code and to select the filter from the web UI.. however, the command line still told me "no filter". I will try to investigate this... - to do so I wanted to start from a fresh installation.

Thanks to your recent fixes, I wanted to give the latest version of the master branch a go (f8715c3).

While following the steps listed in README.md, I ran into a strange build error:

```
pi@raspberrypi:~/self-o-mat $ mkdir build
pi@raspberrypi:~/self-o-mat $ cd build/
pi@raspberrypi:~/self-o-mat/build $ cmake ..
...
CMake Error at CMakeLists.txt:44 (add_subdirectory):
  The source directory

    /home/pi/self-o-mat/dependencies/served

  does not contain a CMakeLists.txt file.
```

It quickly became clear to me that the fresh git repository checkout was lacking the served git submodule (`pi@raspberrypi:~/self-o-mat/dependencies/served $ ls`confirmed that the folder was indeed empty). This is due to one of our recent changes:

https://github.com/maehw/self-o-mat/commit/98d0bdabfc93d0b094f3fecf293c2f5fe70eeb73#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5

I believe that for some time the `--recursive` was not neccessary but now needs to be added back again. Let's add it back so that other beginners will also be able to build this nice piece of FOSS! :)

Cheers
Mäh