### PR TITLE
Add grayscale image filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(self_o_mat.app
         src/tools/readfile.cpp
         src/tools/cobs.cpp src/logic/SelfomatController.cpp
         src/logic/filters/BasicImageFilter.cpp
+        src/logic/filters/GrayscaleImageFilter.cpp
         src/logic/filters/IImageFilter.cpp
         src/tools/verbose.cpp)
 
@@ -91,7 +92,13 @@ target_link_libraries(self_o_mat.app ${Boost_LIBRARIES}
         spdlog::spdlog
 )
 
-add_executable(filter_test src/main_filter.cpp src/logic/filters/IImageFilter.h src/logic/filters/BasicImageFilter.cpp src/logic/filters/BasicImageFilter.h src/logic/filters/IImageFilter.cpp)
+add_executable(filter_test src/main_filter.cpp
+        src/logic/filters/IImageFilter.h
+        src/logic/filters/BasicImageFilter.cpp
+        src/logic/filters/BasicImageFilter.h
+        src/logic/filters/GrayscaleImageFilter.cpp
+        src/logic/filters/GrayscaleImageFilter.h
+        src/logic/filters/IImageFilter.cpp)
 target_link_libraries(filter_test ${Boost_LIBRARIES})
 target_link_libraries(filter_test ${OpenCV_LIBS})
 

--- a/src/logic/BoothLogic.cpp
+++ b/src/logic/BoothLogic.cpp
@@ -389,6 +389,8 @@ void BoothLogic::printerThread() {
                 saveImage(latestJpegBuffer, latestJpegBufferSize, latestJpegFileName, false, true);
 
                 cv::Mat toPrepare;
+                int filterChoice = getFilterChoice();
+                LOG_D(TAG, "[Printer Thread] Filter choice (numeric): ", std::to_string(filterChoice));
                 if (templateEnabled) {
                     toPrepare = imageProcessor.frameImageForPrint(latestJpegBuffer, latestJpegBufferSize, getFilter(),
                                                                   filterGain);
@@ -954,6 +956,8 @@ FILTER BoothLogic::getFilter() {
             return NO_FILTER;
         case 1:
             return BASIC_FILTER;
+	case 2:
+	    return GRAYSCALE_FILTER;
     }
     return NO_FILTER;
 }

--- a/src/logic/ImageProcessor.cpp
+++ b/src/logic/ImageProcessor.cpp
@@ -324,6 +324,10 @@ void ImageProcessor::applyFilter(cv::Mat &image, FILTER filter, double gain) {
             LOG_D(TAG, "basic filter with gain: ", std::to_string(gain));
             basicFilter.processImage(image, gain);
             break;
+        case GRAYSCALE_FILTER:
+            LOG_D(TAG, "grayscale filter");
+            grayscaleFilter.processImage(image, gain);
+            break;
         default:
             LOG_D(TAG, "No Filter");
             break;

--- a/src/logic/ImageProcessor.h
+++ b/src/logic/ImageProcessor.h
@@ -15,6 +15,7 @@
 #include <tools/JpegDecoder.h>
 #include <opencv2/opencv.hpp>
 #include "logic/filters/BasicImageFilter.h"
+#include "logic/filters/GrayscaleImageFilter.h"
 
 
 using namespace selfomat::tools;
@@ -24,10 +25,11 @@ namespace selfomat {
 
         enum FILTER {
             NO_FILTER = 0,
-            BASIC_FILTER = 1
+            BASIC_FILTER = 1,
+            GRAYSCALE_FILTER = 2
         };
 
-        const std::vector<std::string> filterNames { "No Filter", "Basic Filter" };
+        const std::vector<std::string> filterNames { "No Filter", "Basic Filter", "Grayscale Filter" };
 
         class ImageProcessor {
         private:
@@ -45,6 +47,7 @@ namespace selfomat {
             void writeOffset(cv::Rect offset, std::string filename);
 
             BasicImageFilter basicFilter;
+            GrayscaleImageFilter grayscaleFilter;
 
             void applyFilter(cv::Mat &image, FILTER filter, double gain);
 

--- a/src/logic/filters/GrayscaleImageFilter.cpp
+++ b/src/logic/filters/GrayscaleImageFilter.cpp
@@ -1,0 +1,26 @@
+//
+// Created by maehw on 08.03.2025
+//
+
+#include "GrayscaleImageFilter.h"
+
+using namespace selfomat::logic;
+
+void GrayscaleImageFilter::processImage(cv::Mat &image, double gain) {
+    // Ignore the gain parameter
+    (void)gain;
+
+    // Convert the color image to grayscale
+    cv::Mat grayImage;
+    cv::cvtColor(image, grayImage, cv::COLOR_BGR2GRAY);
+
+    // Clip pixel values to the valid range [0, 255]
+    cv::threshold(grayImage, grayImage, 255, 255, cv::THRESH_TRUNC);
+
+    // Convert grayscale image back to 3-channel format to maintain consistency
+    cv::cvtColor(grayImage, image, cv::COLOR_GRAY2BGR);
+}
+
+std::string GrayscaleImageFilter::getName() {
+    return "grayscale_image_filter";
+}

--- a/src/logic/filters/GrayscaleImageFilter.h
+++ b/src/logic/filters/GrayscaleImageFilter.h
@@ -1,0 +1,25 @@
+//
+// Created by maehw on 08.03.2025.
+//
+
+#ifndef SELF_O_MAT_GRAYSCALEIMAGEFILTER_H
+#define SELF_O_MAT_GRAYSCALEIMAGEFILTER_H
+
+
+#include "IImageFilter.h"
+#include <iostream>
+
+namespace selfomat {
+    namespace logic {
+        class GrayscaleImageFilter : public IImageFilter {
+        public:
+            std::string getName() override;
+
+            void processImage(cv::Mat &image, double gain) override;
+        };
+
+    }
+}
+
+
+#endif //SELF_O_MAT_GRAYSCALEIMAGEFILTER_H

--- a/src/main_filter.cpp
+++ b/src/main_filter.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <logic/filters/IImageFilter.h>
 #include <logic/filters/BasicImageFilter.h>
+#include <logic/filters/GrayscaleImageFilter.h>
 #include <iostream>
 #include <boost/filesystem.hpp>
 #include <string>
@@ -12,15 +13,13 @@ using namespace boost::filesystem;
 int main(int argc, char *argv[]) {
 
     if(argc != 2) {
-        std::cout << "Usage: ./filter_test <image in dir> <image out dir>" << std::endl;
+        std::cout << "Usage: ./filter_test <image in dir>" << std::endl;
         return 1;
     }
 
-
-
-
     std::vector<IImageFilter*> filters;
     filters.push_back(new BasicImageFilter());
+    filters.push_back(new GrayscaleImageFilter());
 
     path p(argv[1]);
     directory_iterator end_itr;
@@ -50,7 +49,9 @@ int main(int argc, char *argv[]) {
 
 
             for(auto &filter : filters) {
+                printf("running filter %s\n", filter->getName().c_str());
                 for(double d = 0.0; d <= 1.0; d+=0.25) {
+                    printf("d = %.2lf\n", d);
                     clock_gettime(CLOCK_MONOTONIC, &tstart);
                     image = cv::imread(current_file);
 
@@ -60,7 +61,7 @@ int main(int argc, char *argv[]) {
 
                     clock_gettime(CLOCK_MONOTONIC, &tend);
 
-                    printf("loading took %.5f s\n",
+                    printf("loading took %.5lf s\n",
                            ((double)tend.tv_sec + 1.0e-9*tend.tv_nsec) -
                            ((double)tstart.tv_sec + 1.0e-9*tstart.tv_nsec));
                     clock_gettime(CLOCK_MONOTONIC, &tstart);
@@ -71,7 +72,7 @@ int main(int argc, char *argv[]) {
                     filter->processImage(image, d);
                     clock_gettime(CLOCK_MONOTONIC, &tend);
 
-                    printf("filtering took %.5f s\n",
+                    printf("filtering took %.5lf s\n",
                            ((double)tend.tv_sec + 1.0e-9*tend.tv_nsec) -
                            ((double)tstart.tv_sec + 1.0e-9*tstart.tv_nsec));
 
@@ -85,7 +86,7 @@ int main(int argc, char *argv[]) {
             }
             clock_gettime(CLOCK_MONOTONIC, &tend);
 
-            printf("filtering took %.5f s\n",
+            printf("overall filtering took %.5lf s\n",
                    ((double)tend.tv_sec + 1.0e-9*tend.tv_nsec) -
                    ((double)tstart.tv_sec + 1.0e-9*tstart.tv_nsec));
 


### PR DESCRIPTION
This is a preparation to work on templates + filters (see also: https://github.com/xtech/self-o-mat/issues/40).

I have implemented a simple grayscale filter which should assist debugging problems that arise when combining templates with filters because the basic filter does some adjustments, but imo they are not clearly visible/ distinguishable from not having applied a filter.

Also fixed usage output in src/main_filter.cpp (because you cannot define the output directory, it's hard-coded) and added some other debug outputs. Nice to have this tiny little tool to test filtering!

This may not add large benefit to self-o-mat, but I think it may assist debugging. And at least some people may want to use grayscale images... 😄 

Biggest benefit is to "demo" what parts of the code need to be changed (which was not 100% intuitive). We may add this to the wiki:

* Add C++ header + implementation file under src/logic/filters/; new class must derive from interface IImageFilter
* To test the new filter, modify `src/main_filter.cpp`: add include for the new header file, add an instance to the vecotr by adding a call to `filters.push_back()`; build the tool and test your filter 😉 
* In src/logic/ImageProcessor.h: add header include, enum value to `FILTER`, and filter name to vector `filterNames`; add instance of the new filter as member variable (compare `basicFilter` + `grayscaleFilter`)
* In src/logic/ImageProcessor.cpp: add case for new `FILTER` enum value and add a call to method `processImage(image, gain)` of the member instance there
* Add new files to the `add_executable()` sections of CMakeLists.txt
* Finally, add mapping of numeric value to `FILTER` enum value inside of `BoothLogic::getFilter()`; otherwise new filter will be presented on the web UI for selection but the actual runtime choice will fall back to `NO_FILTER`; this was a small, unexpected pitfall for me

Happy to get feedback on this, but no rush.

Cheers